### PR TITLE
added tool binaries to usr bin

### DIFF
--- a/internals/cores.sh
+++ b/internals/cores.sh
@@ -47,7 +47,10 @@ compile_cores() {
 install_cores() {
     echo "[+] copying binaries"
     cp -a bin/* "${ROOTDIR}/sbin/"
-    cp -a tools/* "${ROOTDIR}/bin/"
+    for file in `ls tools/*`; do
+        cp -a "tools/${file}" "${ROOTDIR}/bin/"
+        ln -rs "../../bin/{$file}" "{$ROOTDIR}/usr/bin/${file}" 
+    done
     cp -a ../g8ufs/g8ufs "${ROOTDIR}/sbin/"
     pushd "${ROOTDIR}/sbin"
     ln -sf corectl reboot

--- a/internals/cores.sh
+++ b/internals/cores.sh
@@ -47,10 +47,7 @@ compile_cores() {
 install_cores() {
     echo "[+] copying binaries"
     cp -a bin/* "${ROOTDIR}/sbin/"
-    for file in `ls tools/*`; do
-        cp -a "tools/${file}" "${ROOTDIR}/bin/"
-        ln -rs "../../bin/{$file}" "{$ROOTDIR}/usr/bin/${file}" 
-    done
+    cp -a tools/* "${ROOTDIR}/usr/bin/"
     cp -a ../g8ufs/g8ufs "${ROOTDIR}/sbin/"
     pushd "${ROOTDIR}/sbin"
     ln -sf corectl reboot


### PR DESCRIPTION
@muhamadazmy 
this was done since libvirt's default location for using ovs-vsctl is in
/usr/bin/ovs-vsctl not /bin/ovs-vsctl